### PR TITLE
fix some bugs

### DIFF
--- a/screw-extension/src/main/java/cn/smallbun/screw/extension/pojo/dialect/TypeDialect.java
+++ b/screw-extension/src/main/java/cn/smallbun/screw/extension/pojo/dialect/TypeDialect.java
@@ -44,6 +44,8 @@ public interface TypeDialect {
         if (type == null || map == null || map.size() == 0) {
             return null;
         }
+        type = type.toLowerCase();
+        
         if (type.startsWith("date")) {
             return map.get("date");
         }

--- a/screw-extension/src/main/java/cn/smallbun/screw/extension/pojo/execute/PojoExecute.java
+++ b/screw-extension/src/main/java/cn/smallbun/screw/extension/pojo/execute/PojoExecute.java
@@ -70,7 +70,7 @@ public class PojoExecute implements Execute {
             }
             File pathFile = new File(path);
             if (!pathFile.exists()) {
-                boolean mkdir = pathFile.mkdir();
+                boolean mkdir = pathFile.mkdirs();
                 if (!mkdir) {
                     throw new ScrewException("create directory failed");
                 }


### PR DESCRIPTION
path存在多级目录的时候存在创建错误的异常，需要手动创建。
mkdir() 创建此抽象路径名称指定的目录（及只能创建一级的目录，且需要存在父目录）
mkdirs()创建此抽象路径指定的目录，包括所有必须但不存在的父目录。（及可以创建多级目录，无论是否存在父目录）